### PR TITLE
Fix some mobile alignment issues

### DIFF
--- a/beginners-yoga-course.html
+++ b/beginners-yoga-course.html
@@ -22,14 +22,13 @@
 
 <!-- HEADER -->
 <div class="pageHeader__logo"></div>
-<div class="gridCell--row gridCell--padded gridCell--row--justifyCenter">
-  <header class="pageHeader"><a href="index.html">
-    <h1 class="headline pageHeader__headline align--center">
-      <span class="headline__line pageHeader__primary inverted">Prema Healing</span>
-      <span class="headline__line pageHeader__secondary">Cleveland</span>
-    </h1></a>
-  </header>
-</div>
+<header class="pageHeader"><a href="index.html">
+  <h1 class="headline pageHeader__headline align--center">
+    <span class="headline__line pageHeader__primary inverted">Prema Healing</span>
+    <span class="headline__line pageHeader__secondary">Cleveland</span>
+  </h1></a>
+  <div class="sanskrit"></div>
+</header>
 
 <div class="gridCell--row program__row gridCell--row--justifyCenter">
 

--- a/index.html
+++ b/index.html
@@ -23,15 +23,13 @@
 
 <!-- HEADER -------------->
 <div class="pageHeader__logo"></div>
-<div class="gridCell--row gridCell--padded gridCell--row--justifyCenter">
-  <header class="pageHeader"><a href="index.html">
-    <h1 class="headline pageHeader__headline align--center">
-      <span class="headline__line pageHeader__primary inverted">Prema Healing</span>
-      <span class="headline__line pageHeader__secondary">Cleveland</span>
-    </h1></a>
-    <div class="sanskrit"></div>
-  </header>
-</div>
+<header class="pageHeader"><a href="index.html">
+  <h1 class="headline pageHeader__headline align--center">
+    <span class="headline__line pageHeader__primary inverted">Prema Healing</span>
+    <span class="headline__line pageHeader__secondary">Cleveland</span>
+  </h1></a>
+  <div class="sanskrit"></div>
+</header>
 
 <div class="banner uppercase">
   <a href="beginners-yoga-course.html">

--- a/main.css
+++ b/main.css
@@ -155,8 +155,11 @@ h3.headline {
 
 .pageHeader {
   line-height: 1;
-  margin-top: 0rem;
+  margin: 0 auto 2rem;
   text-transform: uppercase;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .pageHeader__logo {
@@ -187,6 +190,7 @@ h3.headline {
 
 .sanskrit {
   display: none;
+  width: 164px;
   height: 37px;
   background: url(img/sanskrit.svg) no-repeat center;
   background-size: contain;

--- a/main.css
+++ b/main.css
@@ -132,13 +132,13 @@ h3.headline {
 .banner {
   padding: 0 1em 1em;
   font-size: 1.5rem;
+  text-align: center;
 }
 
 
 @media screen and (min-width: 60em) {
   .banner {
     margin: 0 auto 30px;
-    text-align: center;
   }
 
   .banner a {


### PR DESCRIPTION
@smellular I fixed the issue you were talking about and made a couple other small updates:

> - Remove `.gridCell--row` node around `.pageHeader`. What we want to do
>   with `.pageHeader` is now a little more specific, so relying on the
>   current grid system here complicates things a bit—easier to ditch it
>   for this special case.
> - Add `.sanskrit` node to `beginners-yoga-course.html`.
> - Update the CSS to always center `.pageHeader`. The most important
>   stuff here are the flexbox styles which are hopefully pretty clear. The
>   `width` was necessary on `.sanskrit` to prevent it from disappearing.
>   It worked before because it was a `div` which is by default `width:
>   100%` but stopped working once I switched `.pageHeader` to flexbox
>   because it no longer had that default width since it's a flex child.

Let me know if you need any additional explanation on these.
